### PR TITLE
Update bb_captouch.h

### DIFF
--- a/src/bb_captouch.cpp
+++ b/src/bb_captouch.cpp
@@ -216,9 +216,12 @@ uint8_t ucTemp[4];
        } else if (I2CTest(GT911_ADDR2)) {
           _iAddr = GT911_ADDR2;
        }
-    } else if (I2CTest(FT6X36_ADDR)) {
+    } else if (I2CTest(FT6X36_ADDR0)) {
        _iType = CT_TYPE_FT6X36;
-       _iAddr = FT6X36_ADDR;
+       _iAddr = FT6X36_ADDR0;
+    } else if (I2CTest(FT6X36_ADDR1)) {
+       _iType = CT_TYPE_FT6X36;
+       _iAddr = FT6X36_ADDR1;
     } else if (I2CTest(CST820_ADDR)) {
        _iType = CT_TYPE_CST820;
        _iAddr = CST820_ADDR;

--- a/src/bb_captouch.cpp
+++ b/src/bb_captouch.cpp
@@ -216,12 +216,12 @@ uint8_t ucTemp[4];
        } else if (I2CTest(GT911_ADDR2)) {
           _iAddr = GT911_ADDR2;
        }
-    } else if (I2CTest(FT6X36_ADDR0)) {
-       _iType = CT_TYPE_FT6X36;
-       _iAddr = FT6X36_ADDR0;
     } else if (I2CTest(FT6X36_ADDR1)) {
        _iType = CT_TYPE_FT6X36;
        _iAddr = FT6X36_ADDR1;
+    } else if (I2CTest(FT6X36_ADDR2)) {
+       _iType = CT_TYPE_FT6X36;
+       _iAddr = FT6X36_ADDR2;
     } else if (I2CTest(CST820_ADDR)) {
        _iType = CT_TYPE_CST820;
        _iAddr = CST820_ADDR;

--- a/src/bb_captouch.h
+++ b/src/bb_captouch.h
@@ -76,7 +76,9 @@ enum {
 
 #define GT911_ADDR1 0x5D
 #define GT911_ADDR2 0x14
+#ifndef FT6X36_ADDR
 #define FT6X36_ADDR 0x38
+#endif
 #define CST820_ADDR 0x15
 #define CST226_ADDR 0x5A
 #define MXT144_ADDR 0x4A

--- a/src/bb_captouch.h
+++ b/src/bb_captouch.h
@@ -76,9 +76,8 @@ enum {
 
 #define GT911_ADDR1 0x5D
 #define GT911_ADDR2 0x14
-#ifndef FT6X36_ADDR
-#define FT6X36_ADDR 0x38
-#endif
+#define FT6X36_ADDR1 0x38
+#define FT6X36_ADDR2 0x48
 #define CST820_ADDR 0x15
 #define CST226_ADDR 0x5A
 #define MXT144_ADDR 0x4A


### PR DESCRIPTION
Some FT6X36 chips have an address of 0X48, which can be changed to an externally defined I2C address.