### PR TITLE
Destructor only for Arduino

### DIFF
--- a/src/bb_captouch.h
+++ b/src/bb_captouch.h
@@ -208,8 +208,9 @@ class BBCapTouch
 {
 public:
     BBCapTouch() { _iOrientation = 0; _iType = CT_TYPE_UNKNOWN;}
-//    ~BBCapTouch() { Wire.end(); }
+#ifdef ARDUINO
     ~BBCapTouch() { myWire->end(); }
+#endif
 
 #ifdef ARDUINO
     int init(int iConfigName);


### PR DESCRIPTION
TwoWire (and myWire) does not exist on a non-arduino environment, fix compilation issues under esp-idf
